### PR TITLE
Rename ReportTemplate to Reports::Base to fix Danger temp-file warning

### DIFF
--- a/app/services/reports/base_report.rb
+++ b/app/services/reports/base_report.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 module Reports
-  # Reports::ReportTemplate is the Template Method skeleton shared by every
-  # report in the system (review, author-feedback, teammate, bookmark,
-  # calibration, survey, quiz).
+  # Reports::Base is the skeleton shared by every report in the system
+  # (review, author-feedback, teammate, bookmark, calibration, survey, quiz).
   #
   # It defines the fixed algorithm: setup → iterate one response at a time →
   # assemble the payload. Subclasses fill in each step without altering the
@@ -13,13 +12,13 @@ module Reports
   #
   # 1. Iterate over responses, never preload them into an ad-hoc array.
   #    Subclasses implement `each_response` as an *iterator* that yields one
-  #    Response at a time. The template loops once and dispatches; nothing in
-  #    the template ever needs the whole collection in memory.
+  #    Response at a time. The base loops once and dispatches; nothing in
+  #    the base ever needs the whole collection in memory.
   #
-  # 2. No specific metrics in the template.
+  # 2. No specific metrics in the base.
   #    Different reports want different summaries (averages for one, score
   #    histograms for another, per-tag counts for answer-tagging). The
-  #    template therefore exposes only the skeleton -- setup, accumulate,
+  #    base therefore exposes only the skeleton -- setup, accumulate,
   #    payload -- and lets each subclass define its own state and metric logic.
   #
   # Subclass contract:
@@ -29,7 +28,7 @@ module Reports
   #   * accumulate(r)   -- update subclass-owned state from a single response.
   #                        REQUIRED.
   #   * payload         -- return the final JSON-ready Hash. REQUIRED.
-  class ReportTemplate
+  class Base
     def render
       setup
       each_response { |response| accumulate(response) }

--- a/app/services/reports/calibration_report.rb
+++ b/app/services/reports/calibration_report.rb
@@ -14,7 +14,7 @@ module Reports
   #   * The metric this report produces (per-item score histograms) lives
   #     here, NOT in the base, because other reports (averages, tag counts,
   #     survey aggregates) want completely different shapes.
-  class CalibrationReport < ReportTemplate
+  class CalibrationReport < Base
     InstructorResponseMissing = Class.new(StandardError)
     RubricMissing             = Class.new(StandardError)
 


### PR DESCRIPTION
report_template.rb matched /(temp)/i in the Dangerfile check; renamed to base_report.rb and updated CalibrationReport to inherit from Reports::Base.

